### PR TITLE
Fix webpack asset paths to use se7enxweb package names

### DIFF
--- a/src/bundle/Resources/encore/ez.css.config.js
+++ b/src/bundle/Resources/encore/ez.css.config.js
@@ -5,13 +5,13 @@ module.exports = (Encore) => {
         path.resolve(__dirname, '../public/scss/ezplatform-bootstrap.scss'),
         path.resolve(__dirname, '../public/scss/ezplatform.scss'),
         path.resolve(__dirname, '../public/scss/ui/ezplatform-modules.scss'),
-        path.resolve('./vendor/ezsystems/ezplatform-admin-ui-assets/Resources/public/vendors/flatpickr/dist/flatpickr.min.css'),
+        path.resolve('./vendor/se7enxweb/ezplatform-admin-ui-assets/Resources/public/vendors/flatpickr/dist/flatpickr.min.css'),
     ])
         .addEntry('ezplatform-admin-ui-content-edit-parts-css', [
-            path.resolve('./vendor/ezsystems/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.css'),
+            path.resolve('./vendor/se7enxweb/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.css'),
         ])
         .addEntry('ezplatform-admin-ui-location-view-css', [
-            path.resolve('./vendor/ezsystems/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.css'),
+            path.resolve('./vendor/se7enxweb/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.css'),
         ])
         .addEntry('ezplatform-admin-ui-security-base-css', [
             path.resolve(__dirname, '../public/scss/ezplatform-bootstrap.scss'),

--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -141,7 +141,7 @@ module.exports = (Encore) => {
             path.resolve(__dirname, '../public/js/scripts/sidebar/btn/user.edit.js'),
             path.resolve(__dirname, '../public/js/scripts/sidebar/btn/location.create.js'),
             path.resolve(__dirname, '../public/js/scripts/sidebar/instant.filter.js'),
-            path.resolve('./vendor/ezsystems/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.js'),
+            path.resolve('./vendor/se7enxweb/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.location.load.map.js'),
             path.resolve(__dirname, '../public/js/scripts/sidebar/btn/content.edit.js'),
             path.resolve(__dirname, '../public/js/scripts/sidebar/btn/content.hide.js'),
@@ -173,7 +173,7 @@ module.exports = (Encore) => {
         .addEntry('ezplatform-admin-ui-link-manager-view-js', [path.resolve(__dirname, '../public/js/scripts/button.content.edit.js')])
         .addEntry('ezplatform-admin-ui-change-user-password-js', [path.resolve(__dirname, '../public/js/scripts/user_password.change.js')])
         .addEntry('ezplatform-admin-ui-content-edit-parts-js', [
-            path.resolve('./vendor/ezsystems/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.js'),
+            path.resolve('./vendor/se7enxweb/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.location.tab.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.content.edit.js'),
             path.resolve(__dirname, '../public/js/scripts/fieldType/base/base-field.js'),


### PR DESCRIPTION
Updated webpack encore configuration files to reference the correct se7enxweb package paths instead of legacy ezsystems paths:

- Fixed flatpickr.min.css path in ez.css.config.js
- Fixed leaflet.css paths in ez.css.config.js
- Fixed leaflet.js paths in ez.js.config.js

This ensures webpack can find the required vendor assets when using the maintained se7enxweb package ecosystem.

| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
