### PR TITLE
Fix HTML title tag branding: Replace 'Ibexa DXP' with 'Exponential Pl…

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -91,7 +91,7 @@
             </script>
             <script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
         {% endif %}
-        <title>{% block title %}Ibexa DXP{% endblock %}</title>
+        <title>{% block title %}Exponential Platform{% endblock %}</title>
         {{ encore_entry_link_tags('ezplatform-admin-ui-layout-css', null, 'ezplatform') }}
         {% block stylesheets %}{% endblock %}
         <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />


### PR DESCRIPTION
…atform'

- Update main admin layout title tag from Ibexa DXP to Exponential Platform
- Ensures consistent branding across admin interface browser titles
- Critical branding fix for 3.2++ release

Files updated:
- src/bundle/Resources/views/themes/admin/ui/layout.html.twig (title tag only)

| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
